### PR TITLE
fix: improve plot reproducibility

### DIFF
--- a/src/lonpy/visualization.py
+++ b/src/lonpy/visualization.py
@@ -1,6 +1,8 @@
+import random
 import shutil
 from pathlib import Path
 
+import igraph as ig
 import imageio
 import matplotlib.pyplot as plt
 import numpy as np
@@ -147,6 +149,7 @@ class LONVisualizer:
         """Get 2D layout coordinates for graph nodes."""
         if seed is not None:
             np.random.seed(seed)
+            ig.set_random_number_generator(random.Random(seed))
         layout = graph.layout_auto()
         return np.array(layout.coords)
 


### PR DESCRIPTION
Previously, plotting with a fixed seed still produced different graph layouts. The reason was that the NumPy random seed was set, but igraph does not rely on NumPy's RNG.
This PR fixes the issue by explicitly setting igraph's random number generator via `igraph.set_random_number_generator(random.Random(seed))`, ensuring that igraph's internal randomness is properly seeded.